### PR TITLE
add media query for age box contents; remove background colour

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -57,19 +57,23 @@
   display: grid;
   grid-template-columns: repeat(2, auto);
   grid-template-rows: repeat(4, 1fr);
-  gap: 10px;
-  background-color: rgb(0, 15, 88);
+  background-color: black;
   width: 80%;
   margin: 0 auto;
   max-width: 1200px;
 }
 
+@media screen and (max-width: 1150px) {
+  .planet-age-boxes-container {
+    grid-template-columns: repeat(1, auto);
+    grid-template-rows: repeat(8, 1fr);
+  }
+}
+
 .planet {
   display: grid;
   grid-template-columns: 1fr 3fr;
-  grid-template-rows: 1fr 1fr;
   margin: 10px;
-  gap: 10px;
   color: white;
   font-family: "Space Grotesk", sans-serif;
 }
@@ -82,7 +86,8 @@
 }
 
 .planet-age {
-  font-weight: 600;
+  font-weight: 800;
+  font-size: 2rem;
 }
 
 .footer-container {


### PR DESCRIPTION
This PR:
 - Amends row spacing/text size for planet age box contents.
 - Removes blue background for planet age box contents.
 - Adds a media query to ensure smaller width displays do not cluster planet age box contents.