### PR TITLE
Party planner footer at bottom

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -178,11 +178,11 @@
 .party-planner-page-container {
   display: grid;
   grid-template-columns: 1fr 1fr;
-  grid-template-rows: 1fr 1fr;
+  grid-template-rows: auto auto;
   width: 80%;
   margin: 0 auto;
   max-width: 1200px;
-  height: 600px;
+  height: auto;
   background-color: black;
   color: white;
   font-family: "Space Grotesk", sans-serif;

--- a/views/partials/footer.ejs
+++ b/views/partials/footer.ejs
@@ -1,14 +1,1 @@
-<!DOCTYPE html>
-<html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <link rel="stylesheet" href="/css/style.css" />
-    <title>Footer</title>
-  </head>
-  <body>
-    <div class="footer-container">
-      © Glenn Christmas, <%= locals.currentYear%>
-    </div>
-  </body>
-</html>
+<div class="footer-container">© Glenn Christmas, <%= locals.currentYear%></div>

--- a/views/partials/header.ejs
+++ b/views/partials/header.ejs
@@ -1,23 +1,12 @@
-<!DOCTYPE html>
-<html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <link rel="stylesheet" href="/css/style.css" />
-    <title>Header</title>
-  </head>
-  <body>
-    <div class="header-grid-container">
-      <div class="header-links-container">
-        <div class="linkBlank"></div>
-        <a href="https://www.linkedin.com/in/gchristmas/" class="link1">
-          <img src="/assets/LI.png" class="social-media-logo" />
-        </a>
-        <a href="https://github.com/GlennChristmas" class="link2">
-          <img src="/assets/GH.png" class="social-media-logo-invert" />
-        </a>
-      </div>
-      <div class="title-container">Solar Age Calculator</div>
-    </div>
-  </body>
-</html>
+<div class="header-grid-container">
+  <div class="header-links-container">
+    <div class="linkBlank"></div>
+    <a href="https://www.linkedin.com/in/gchristmas/" class="link1">
+      <img src="/assets/LI.png" class="social-media-logo" />
+    </a>
+    <a href="https://github.com/GlennChristmas" class="link2">
+      <img src="/assets/GH.png" class="social-media-logo-invert" />
+    </a>
+  </div>
+  <div class="title-container">Solar Age Calculator</div>
+</div>

--- a/views/partials/modal.ejs
+++ b/views/partials/modal.ejs
@@ -1,23 +1,12 @@
-<!DOCTYPE html>
-<html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <link rel="stylesheet" href="/css/style.css" />
-    <title>Document</title>
-  </head>
-  <body>
-    <% if(locals.modalData){ %> <% for (const planet in modalData) { %>
-    <div class="planet-container <%= planet %>">
-      <h3><%= planet %></h3>
-      <% const details = modalData[planet]; %> <% for (const key in details) {
-      /*note - we are using nested 'for in' loops here - these are useful to
-      loop through objects */ %>
-      <div class="planet-detail <%=key%>">
-        <strong><%= key %>:</strong> <%= details[key] %>
-      </div>
-      <% } %>
-    </div>
-    <% } %> <% } %>
-  </body>
-</html>
+<% if(locals.modalData){ %> <% for (const planet in modalData) { %>
+<div class="planet-container <%= planet %>">
+  <h3><%= planet %></h3>
+  <% const details = modalData[planet]; %> <% for (const key in details) {
+  /*note - we are using nested 'for in' loops here - these are useful to loop
+  through objects */ %>
+  <div class="planet-detail <%=key%>">
+    <strong><%= key %>:</strong> <%= details[key] %>
+  </div>
+  <% } %>
+</div>
+<% } %> <% } %>


### PR DESCRIPTION
Style for `party-planner-page-container` was causing issues for the footer as arbitrary 600px placeholder value now overlapped with content. Replaced with `auto`. Likewise, grid rows amended from arbitrary `1fr` height to instead take up `auto` space depending on contents.

PR also removes unecessary HTML from EJS partials.