### PR TITLE
bug fix: ensure guest list is hidden for *all* instances of a guest add modal being open

### DIFF
--- a/public/guestListModal.js
+++ b/public/guestListModal.js
@@ -3,15 +3,15 @@ document.addEventListener("DOMContentLoaded", (event) => {
   const guestListAdd = document.querySelector(".guest-list-add");
   const guestListModal = document.querySelector(".guest-list-modal");
   const guestListSubmit = document.querySelector(".guest-list-submit");
-  const guestListDisplay = document.querySelector(".guest-record-container");
 
-  //open modal
+  //open and close modal
   guestListAdd.addEventListener("click", () => {
     guestListModal.classList.remove("hidden");
     guestListSubmit.classList.remove("hidden");
     guestListAdd.classList.add("hidden");
-    guestListDisplay.classList.add("hidden");
-  });
 
-  //close modals
+    document.querySelectorAll(".guest-record-container").forEach((element) => {
+      element.classList.add("hidden");
+    });
+  });
 });


### PR DESCRIPTION
This PR corrects existing DOM manipulation, where previously only _one_ element with class `guest-record-container` was having class `hidden` applied on add guest details modal open.