### PR TITLE
Add guest list record delete

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,6 @@ import path from "path";
 import { fileURLToPath } from "url";
 import bodyParser from "body-parser";
 import { v4 as uuidv4 } from "uuid";
-import fs from "fs";
 
 const app = express();
 app.set("view engine", "ejs");
@@ -40,6 +39,8 @@ import { loadPartyDetails } from "./public/loadPartyDetailsCurrent.js";
 import { loadGuestList } from "./public/loadGuestListCurrent.js";
 import { savePartyDetails } from "./public/savePartyDetailsCurrent.js";
 import { keyValueExtractor } from "./public/keyValueExtractor.js";
+import { arrayElementIndexFinder } from "./public/arrayElementIndexFinder.js";
+import { arrayElementDeleter } from "./public/arrayElementDeleter.js";
 
 import partyFormContents from "./data/partyFormContents.json" assert { type: "json" };
 import guestListModalContents from "./data/guestListModalContents.json" assert { type: "json" };

--- a/index.js
+++ b/index.js
@@ -66,49 +66,6 @@ app.get("/party-planning", (req, res) => {
   });
 });
 
-app.post("/submit-party-details", (req, res) => {
-  let partyDetailsObject = req.body;
-
-  partyDetailsCurrent = partyDetailsObject;
-  console.log(partyDetailsCurrent);
-
-  savePartyDetails(partyDetailsCurrent);
-
-  res.render("partyPlanning", {
-    currentYear,
-    partyFormContents,
-    partyDetailsCurrent,
-    keyExists,
-    getValueByKey,
-    keyValueExtractor,
-    guestListModalContents,
-    guestListCurrent,
-  });
-});
-
-app.post("/submit-guest-list", (req, res) => {
-  let guestDetails = req.body;
-  let guestUUID = uuidv4();
-
-  guestDetails["uuid"] = guestUUID;
-
-  //this will add a new record - regardless of whether we are editing another one or not
-  guestListCurrent.push(guestDetails);
-
-  saveGuestList(guestListCurrent);
-
-  res.render("partyPlanning", {
-    currentYear,
-    partyFormContents,
-    partyDetailsCurrent,
-    keyExists,
-    getValueByKey,
-    keyValueExtractor,
-    guestListModalContents,
-    guestListCurrent,
-  });
-});
-
 app.post("/submit-birthdate", (req, res) => {
   let birthDate = req.body.birthDate;
   console.log("Birthdate submitted:", birthDate);
@@ -147,6 +104,47 @@ app.post("/submit-birthdate", (req, res) => {
     modalData,
     modalKeyTitles,
   });
+});
+
+app.post("/submit-party-details", (req, res) => {
+  let partyDetailsObject = req.body;
+
+  partyDetailsCurrent = partyDetailsObject;
+  console.log(partyDetailsCurrent);
+
+  savePartyDetails(partyDetailsCurrent);
+
+  res.redirect("party-planning");
+});
+
+app.post("/submit-guest-list", (req, res) => {
+  let guestDetails = req.body;
+  let guestUUID = uuidv4();
+
+  guestDetails["uuid"] = guestUUID;
+
+  //this will add a new record - regardless of whether we are editing another one or not
+  guestListCurrent.push(guestDetails);
+
+  saveGuestList(guestListCurrent);
+
+  //amended as redirect, rather than re-render required for deletion to work (lightbulb moment as I then realised should be applied elsewhere!)
+  res.redirect("party-planning");
+});
+
+app.post("/delete-guest", (req, res) => {
+  let myKey = req.body.recordUUID;
+
+  let deletionIndex = arrayElementIndexFinder(guestListCurrent, myKey);
+
+  let guestListCurrentWithDeletion = arrayElementDeleter(
+    guestListCurrent,
+    deletionIndex
+  );
+
+  saveGuestList(guestListCurrentWithDeletion);
+
+  res.redirect("party-planning");
 });
 
 const PORT = process.env.PORT || 4000;

--- a/public/arrayElementDeleter.js
+++ b/public/arrayElementDeleter.js
@@ -1,0 +1,11 @@
+export const arrayElementDeleter = function (array, index) {
+  const newArray = array.slice();
+  if (index >= 0 && index < newArray.length) {
+    newArray.splice(index, 1);
+  } else {
+    console.log("Error deleting record, please contact the developer.");
+    return;
+  }
+
+  return newArray;
+};

--- a/public/arrayElementIndexFinder.js
+++ b/public/arrayElementIndexFinder.js
@@ -1,0 +1,11 @@
+export const arrayElementIndexFinder = function (arr, key) {
+  //implementing copy on write approach from Grokking Simplicity
+  let newArr = arr.slice();
+
+  for (let i = 0; i < newArr.length; i++) {
+    let elementUUID = newArr[i].uuid;
+    if (elementUUID == key) {
+      return i;
+    }
+  }
+};

--- a/public/listenForGuestRecordAmendment.js
+++ b/public/listenForGuestRecordAmendment.js
@@ -1,0 +1,40 @@
+document.addEventListener("DOMContentLoaded", (event) => {
+  const guestRecordEdit = document.querySelectorAll(
+    ".guest-record-button.edit"
+  );
+  const guestRecordDelete = document.querySelectorAll(
+    ".guest-record-button.delete"
+  );
+
+  //listen out for guest record deletions
+  for (let i = 0; i < guestRecordDelete.length; i++) {
+    guestRecordDelete[i].addEventListener("click", (event) => {
+      //extract record id from element and assign to var
+      var recordUUID = event.currentTarget.getAttribute("data-id");
+
+      //in order to send something to the server, it must be in a string format - JSON is often used for this
+      let jsonString = JSON.stringify({ recordUUID: recordUUID });
+
+      //now send a POST request to server with body contents being the jsonString generated above
+      fetch("/delete-guest", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: jsonString,
+      })
+        .then((response) => {
+          if (!response.ok) {
+            throw new Error(`HTTP error! status: ${response.status}`);
+          }
+          return response.json();
+        })
+        .then((data) => {
+          console.log("Success:", data);
+        })
+        .catch((error) => {
+          console.error("Error:", error);
+        });
+    });
+  }
+});

--- a/public/listenForGuestRecordAmendment.js
+++ b/public/listenForGuestRecordAmendment.js
@@ -28,7 +28,7 @@ document.addEventListener("DOMContentLoaded", (event) => {
             throw new Error(`HTTP error! status: ${response.status}`);
           }
           //required for DOM to update when record is deleted - as fetch more ordinarily used in single page applications
-          window.location.reload();
+          location.reload();
         })
         .then((data) => {
           console.log("Success:", data);

--- a/public/listenForGuestRecordAmendment.js
+++ b/public/listenForGuestRecordAmendment.js
@@ -27,7 +27,8 @@ document.addEventListener("DOMContentLoaded", (event) => {
           if (!response.ok) {
             throw new Error(`HTTP error! status: ${response.status}`);
           }
-          return response.json();
+          //required for DOM to update when record is deleted - as fetch more ordinarily used in single page applications
+          window.location.reload();
         })
         .then((data) => {
           console.log("Success:", data);

--- a/views/partyPlanning.ejs
+++ b/views/partyPlanning.ejs
@@ -13,6 +13,7 @@
     <script type="module" src="/keyExists.js"></script>
     <script type="module" src="/getValueByKey.js"></script>
     <script type="module" src="/guestListModal.js"></script>
+    <script type="module" src="/listenForGuestRecordAmendment.js"></script>
     <title>Party Planning</title>
   </head>
   <body>


### PR DESCRIPTION
This PR
- Adds functionality to delete guest records (note: edit button is not yet enabled).
- Amends `index.js` patterns: previously res.render of e.g. `partyPlanning.ejs` used to occur at the end of `POST` requests. Instead, `res.redirect` is used. This was required for deletion to work, but also has a side effect of improving readability, so I extended this to all `POST` request handling.
- Reorders `index.js` HTTP request handling order to place `GET` handling at the top, followed by our handling of `POST` requests, to improve readability.

I have attempted to use the copy-on-write approach advocated in [Grokking Simplicity](https://www.manning.com/books/grokking-simplicity) to try and work with more pure functions (that e.g. don't risk causing unexpected side effects for global objects). This has not been applied retroactively, so the current codebase contains a mixture of approaches. This is tech debt that could be dealt with in future.