### PR TITLE
Edit/Delete guest records - Async await refactor for front end logic

### DIFF
--- a/index.js
+++ b/index.js
@@ -93,8 +93,6 @@ app.post("/guest-edit-send-uuid", (req, res) => {
   let elementIndex = findIndexInArray(guestListCurrent, guestId);
   elementForEdit = guestListCurrent[elementIndex];
 
-  console.log(elementForEdit);
-
   res.status(200).json({
     message: "Guest found for edit",
     elementForEdit: elementForEdit,

--- a/public/js/listenForGuestRecordAmendment.js
+++ b/public/js/listenForGuestRecordAmendment.js
@@ -30,9 +30,6 @@ document.addEventListener("DOMContentLoaded", (event) => {
 
         //required for DOM to update when record is deleted
         location.reload();
-
-        let data = await response.json();
-        console.log("Success: ", data);
       } catch (error) {
         console.error("Error: ", error);
       }
@@ -41,68 +38,57 @@ document.addEventListener("DOMContentLoaded", (event) => {
 
   //listen out for guest record edits
   for (let i = 0; i < guestRecordEdit.length; i++) {
-    guestRecordEdit[i].addEventListener("click", (event) => {
+    guestRecordEdit[i].addEventListener("click", async (event) => {
       let recordUUID = event.currentTarget.getAttribute("data-id");
 
-      fetch("/guest-edit-send-uuid", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({ guestId: recordUUID }),
-      })
-        .then((response) => {
-          if (!response.ok) {
-            throw new Error(
-              "Technical issues extracting the guest record, sorry."
-            );
-          }
-          return response.json();
-        })
-        .then((data) => {
-          console.log("hello there!");
-          console.log("Success: ", data);
-          return fetch("/party-planning-guest-edit", {
-            method: "GET",
-          });
-        })
-        .then((response) => {
-          if (!response.ok) {
-            throw new Error(
-              "Technical issues loading the page to edit the guest record, sorry."
-            );
-          }
-          return response.text();
-        })
-        .then((html) => {
-          console.log("GET request was successful: ");
-          //use the generated html to overwrite existing client-side contents
-          document.open();
-          document.write(html);
-          document.close();
-        })
-        .then(() => {
-          console.log(
-            "Now rerendering party-planning page with guest list element to edit..."
-          );
-          //unfortunately the previous promise means the document has been replaced
-          //we'll therefore need to remap guestListAdd/Modal/Submit again - we probably ought to find a cleaner way of doing this
-          const guestListAdd = document.querySelector(".guest-list-add");
-          const guestListModal = document.querySelector(".guest-list-modal");
-          const guestListSubmit = document.querySelector(".guest-list-submit");
-          guestListModal.classList.remove("hidden");
-          guestListSubmit.classList.remove("hidden");
-          guestListAdd.classList.add("hidden");
-
-          document
-            .querySelectorAll(".guest-record-container")
-            .forEach((element) => {
-              element.classList.add("hidden");
-            });
-        })
-        .catch((error) => {
-          console.error("Error: ", error);
+      try {
+        const sendUUID = await fetch("/guest-edit-send-uuid", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ guestId: recordUUID }),
         });
+
+        if (!sendUUID.ok) {
+          throw new Error(
+            "Technical issues extracting the guest record, sorry."
+          );
+        }
+
+        const loadPartyPlanning = await fetch("/party-planning-guest-edit", {
+          method: "GET",
+        });
+
+        if (!loadPartyPlanning.ok) {
+          throw new Error(
+            "Technical issues loading the page to edit the guest record, sorry."
+          );
+        }
+
+        const html = await loadPartyPlanning.text();
+        //use the generated html to overwrite existing client-side contents
+        document.open();
+        document.write(html);
+        document.close();
+
+        //unfortunately the previous promise means the document has been replaced
+        //we'll therefore need to remap guestListAdd/Modal/Submit again - we probably ought to find a cleaner way of doing this
+        const guestListAdd = document.querySelector(".guest-list-add");
+        const guestListModal = document.querySelector(".guest-list-modal");
+        const guestListSubmit = document.querySelector(".guest-list-submit");
+        guestListModal.classList.remove("hidden");
+        guestListSubmit.classList.remove("hidden");
+        guestListAdd.classList.add("hidden");
+
+        document
+          .querySelectorAll(".guest-record-container")
+          .forEach((element) => {
+            element.classList.add("hidden");
+          });
+      } catch (error) {
+        console.error("Error: ", error);
+      }
     });
   }
 });

--- a/public/js/listenForGuestRecordAmendment.js
+++ b/public/js/listenForGuestRecordAmendment.js
@@ -6,36 +6,36 @@ document.addEventListener("DOMContentLoaded", (event) => {
     ".guest-record-button.delete"
   );
 
-  //listen out for guest record deletions
+  //Listen out for guest record deletions
   for (let i = 0; i < guestRecordDelete.length; i++) {
-    guestRecordDelete[i].addEventListener("click", (event) => {
-      //extract record id from element and assign to var
-      var recordUUID = event.currentTarget.getAttribute("data-id");
+    guestRecordDelete[i].addEventListener("click", async (event) => {
+      try {
+        //Extract record id from element and assign to var
+        var recordUUID = event.currentTarget.getAttribute("data-id");
+        let jsonString = JSON.stringify({ recordUUID: recordUUID });
 
-      //in order to send something to the server, it must be in a string format - JSON is often used for this
-      let jsonString = JSON.stringify({ recordUUID: recordUUID });
+        //Now send a POST request to server with body contents being the jsonString generated above
 
-      //now send a POST request to server with body contents being the jsonString generated above
-      fetch("/delete-guest", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: jsonString,
-      })
-        .then((response) => {
-          if (!response.ok) {
-            throw new Error(`HTTP error! status: ${response.status}`);
-          }
-          //required for DOM to update when record is deleted - as fetch more ordinarily used in single page applications
-          location.reload();
-        })
-        .then((data) => {
-          console.log("Success:", data);
-        })
-        .catch((error) => {
-          console.error("Error:", error);
+        let response = await fetch("/delete-guest", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: jsonString,
         });
+
+        if (!response.ok) {
+          throw new Error(`HTTP error! status: ${response.status}`);
+        }
+
+        //required for DOM to update when record is deleted
+        location.reload();
+
+        let data = await response.json();
+        console.log("Success: ", data);
+      } catch (error) {
+        console.error("Error: ", error);
+      }
     });
   }
 
@@ -81,7 +81,7 @@ document.addEventListener("DOMContentLoaded", (event) => {
           document.write(html);
           document.close();
         })
-        .then((html) => {
+        .then(() => {
           console.log(
             "Now rerendering party-planning page with guest list element to edit..."
           );


### PR DESCRIPTION
This PR
- Refactors `.then` promise consumption chains used in handling `fetch` calls and related DOM manipulation after an event listener has picked up on the user clicking `edit` or `delete` for a guest record. I have tried to implement an approach that uses `async/await` as I understand this is a very common approach to improve readibility (i.e. by removing callbacks and making code appear as though it's executing sequentially).
- Removes various `console.log` calls left over from testing the original logic.